### PR TITLE
Visual Studio 2010 build fails. Fixed.

### DIFF
--- a/src/core/pbrt.h
+++ b/src/core/pbrt.h
@@ -83,14 +83,14 @@ using std::sort;
 #include <float.h>
 #define isnan _isnan
 #define isinf(f) (!_finite((f)))
-#define int8_t __int8
-#define uint8_t unsigned __int8
-#define int16_t __int16
-#define uint16_t unsigned __int16
-#define int32_t __int32
-#define uint32_t unsigned __int32
-#define int64_t __int64
-#define uint64_t unsigned __int64
+typedef __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef __int64 int64_t;
+typedef unsigned __int64 uint64_t;
 #pragma warning (disable : 4305) // double constant assigned to float
 #pragma warning (disable : 4244) // int -> float conversion
 #pragma warning (disable : 4267) // size_t -> unsigned int conversion


### PR DESCRIPTION
Visual studio 2010 fails when building.

This commit will fix the problem.

The problem is due to conflicting information in pbrt.h, that is guarded for inclusion only in windows (#if defined(PBRT_IS_WINDOWS) and in targa.h, which is guarded for inclusion only with visual studio (#ifdef _MSC_VER).

Changing the #defines in pbrt.h to typdefs solves the problem.

The error messages if you are interested are of the form:

```
1>p:\pbrt-v2.mmp\src\core\targa.h(24): warning C4114: same type qualifier used more than once
1>p:\pbrt-v2.mmp\src\core\targa.h(24): error C2632: 'char' followed by 'char' is illegal
1>p:\pbrt-v2.mmp\src\core\targa.h(24): warning C4091: 'typedef ' : ignored on left of 'unsigned char' when no variable is declared
```
