### PR TITLE
Fix pfm file writer

### DIFF
--- a/src/core/imageio.cpp
+++ b/src/core/imageio.cpp
@@ -433,8 +433,8 @@ static bool WriteImagePFM(const string &filename, const float *rgb,
     // row ordered left to right and the rows ordered bottom to top.
     nFloats = 3 * width * height;
     for (int j=height-1; j>=0; j--) {
-	if (fwrite(rgb + j*width*3, sizeof(float), width*3, fp) < width*3)
-	    goto fail;
+        if (fwrite(rgb + j*width*3, sizeof(float), width*3, fp) < width*3)
+            goto fail;
     }
 
     fclose(fp);


### PR DESCRIPTION
Small patch to fix WriteImagePFM() function.

In the original it did not take into consideration that the pfm file format assume the image to be stored from bottom to top row and not viceversa.

Compare specification as in http://netpbm.sourceforge.net/doc/pfm.html
