### PR TITLE
0 is incorrectly considered a power of 2 in function IsPowerOf2

### DIFF
--- a/src/core/pbrt.h
+++ b/src/core/pbrt.h
@@ -261,7 +261,7 @@ inline int Log2Int(float v) {
 
 
 inline bool IsPowerOf2(int v) {
-    return (v & (v - 1)) == 0;
+    return v && !(v & (v - 1));
 }
 
 


### PR DESCRIPTION
In file /src/core/pbrt.h, fuction IsPowerOf2, 0 is considered a power of 2. 
The remedy is straight forward. Please check it out.
