### PR TITLE
Fixes for VS2012 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ src/pbrt.vs*/*.sdf
 src/pbrt.vs*/*.opensdf
 src/pbrt.vs*/ipch
 src/pbrt.vs*/*.suo
+src/pbrt.vs*/*.user
 
 # VS Build folders
 tmp/

--- a/src/pbrt.vs2012/pbrt.sln
+++ b/src/pbrt.vs2012/pbrt.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pbrt", "pbrt.vcxproj", "{7C350267-019A-43D2-BA77-0B3DF4C94EB8}"
 	ProjectSection(ProjectDependencies) = postProject
 		{2E030F4C-B2AE-476C-8E40-A326B3840F6C} = {2E030F4C-B2AE-476C-8E40-A326B3840F6C}


### PR DESCRIPTION
- Correct version of .sln format so it opens in VS2012 instead of 2010 when double-clicked.
- Ignore .user files created by VS.
