### PR TITLE
Remove #error directive for g++ 4.8.2

### DIFF
--- a/src/core/pbrt.h
+++ b/src/core/pbrt.h
@@ -34,12 +34,6 @@
 #pragma once
 #endif
 
-#ifdef __GNUC__
-#if (__GNUC__ == 4) && (__GNUC_MINOR__ == 8) && (__GNUC_PATCHLEVEL__ == 2)
-#error "You're compiling with g++ version 4.8.2, which has a tragic bug in std::nth_element, which in turn causes crashes in pbrt  (http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58800). Please upgrade your version of g++"
-#endif // 4.8.2 borkage
-#endif // __GNUC__
-
 #ifndef PBRT_CORE_PBRT_H
 #define PBRT_CORE_PBRT_H
 


### PR DESCRIPTION
The version number is not enough to know that std::nth_element is buggy.
GCC 4.8.2 is the compiler for both Ubuntu 14.04 and CentOS 7, and both
distributions have patched libstdc++ to fix GCC Bug #58800.

At this point, the #error directive is more likely to cause problems
than prevent problems.

Tested with killeroo-gold.pbrt on Ubuntu 14.04 and CentOS 7.
This reverts commit a7bf7eaea319f7927ceb478cd3df95545e5e1d14.
Related Issue: #16 