### PR TITLE
Partial derivatives for Disk.

### DIFF
--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -77,16 +77,26 @@ bool Disk::Intersect(const Ray &r, float *tHit, float *rayEpsilon,
     if (phi > phiMax)
         return false;
 
+    // u = phi / phiMax.
+    // R = radius + v(innerRadius - radius).
+    // x = R cos(phi).
+    // y = R sin(phi).
+    // z = height.
+    // d(px)/du = -phiMax * y.
+    // d(py)/du = phiMax * x.
+    // d(pz)/du = 0.
+    // d(px)/dv = (innerRadius - radius)cos(phi).
+    // d(py)/dv = (innerRadius - radius)sin(phi).
+    // d(pz)/dv = 0.
     // Find parametric representation of disk hit
     float u = phi / phiMax;
-    float oneMinusV = ((sqrtf(dist2)-innerRadius) /
+    float R = sqrtf(dist2);
+    float oneMinusV = ((R-innerRadius) /
                        (radius-innerRadius));
-    float invOneMinusV = (oneMinusV > 0.f) ? (1.f / oneMinusV) : 0.f;
     float v = 1.f - oneMinusV;
     Vector dpdu(-phiMax * phit.y, phiMax * phit.x, 0.);
-    Vector dpdv(-phit.x * invOneMinusV, -phit.y * invOneMinusV, 0.);
-    dpdu *= phiMax * INV_TWOPI;
-    dpdv *= (radius - innerRadius) / radius;
+    Vector dpdv(phit.x, phit.y, 0.); 
+    dpdv *= (innerRadius - radius) / R;
     Normal dndu(0,0,0), dndv(0,0,0);
 
     // Initialize _DifferentialGeometry_ from parametric information


### PR DESCRIPTION
The derivation of partial derivatives for Disk is skipped in the textbook, so I did it by myself and unfortunately got different partial derivatives from the one implemented in disk.cpp.

This pull request contains my partial derivatives for Disk in shapes/disk.cpp and 3 test cases in main/pbrt.cpp. After compiling the source code the tests can be run simply by typing:

./bin/pbrt

(Assume the current directory is src)

Below are the ouput on my laptop(Ubuntu 14.04):
The old method:
analytical dpdu: (0, 2.35619, 0)
analytical dpdv: (-1.5, 0, 0)
du: 0.000212207 dv: -3.57628e-07
numerical dpdu: (0, 4.71239, 0)
du: 0 dv: -0.00100005
numerical dpdv: (-1, -0, -0)
p2: (1.501, 0.001, 1)
p1 + dpdu * du + dpdv * dv: (1.5015, 0.000499667, 1)
relative error: 50.0435%

My method:
analytical dpdu: (0, 4.71239, 0)
analytical dpdv: (-1, -0, -0)
du: 0.000212207 dv: -3.57628e-07
numerical dpdu: (0, 4.71239, 0)
du: 0 dv: -0.00100005
numerical dpdv: (-1, -0, -0)
p2: (1.501, 0.001, 1)
p1 + dpdu * du + dpdv * dv: (1.501, 0.000999334, 1)
relative error: 0.0534819%


