### PR TITLE
Modified prebuild process to automatically find bison and flex

### DIFF
--- a/src/pbrt.vs2012/prebuild.cmd
+++ b/src/pbrt.vs2012/prebuild.cmd
@@ -1,3 +1,30 @@
-nmake prebuild.makefile
+@ECHO OFF
+setlocal EnableDelayedExpansion
+set "winbison="
+set "winflex="
+
+set "drives="
+for /f "delims=" %%a in ('fsutil fsinfo drives') do @set "drives=%%a"
+
+REM :~8 is to slice off "Drives: " returned by fsutil
+for %%i in (%drives:~8%) do (
+	if exist %%iNUL (
+		pushd %%i
+		if not defined winbison (
+			for /f "delims=" %%a in (
+				'dir win_bison.exe /s /b 2^>nul') do @set "winbison=%%a"
+		)
+
+		if not defined winflex (
+			for /f "delims=" %%a in (
+				'dir win_flex.exe /s /b 2^>nul') do @set "winflex=%%a"
+		)
+		popd
+	)
+)
+
+nmake BISON_PROGRAM="%winbison%" FLEX_PROGRAM="%winflex%" prebuild.makefile
 cd ..\3rdparty\ilmbase-1.0.2
 buildLUTS.cmd
+
+@ECHO ON

--- a/src/pbrt.vs2012/prebuild.makefile
+++ b/src/pbrt.vs2012/prebuild.makefile
@@ -1,37 +1,22 @@
 core_dir = ..\core
 
-bison_bin = bison.exe
-bison_cygwin_bin = c:\cygwin\bin\$(bison_bin)
 bison_args = -d -v -t -o $(core_dir)\pbrtparse.cpp $(core_dir)\pbrtparse.yy
-
-flex_bin = flex.exe
-flex_cygwin_bin = c:\cygwin\bin\$(flex_bin)
 flex_args = -o$(core_dir)\pbrtlex.cpp $(core_dir)\pbrtlex.ll
-
-
+	
 .PHONY : $(core_dir)\pbrtparse.cpp $(core_dir)\pbrtlex.cpp
 
-
 $(core_dir)\pbrtparse.cpp $(core_dir)\pbrtparse.hpp : $(core_dir)\pbrtparse.yy
-	if exist $(bison_cygwin_bin) \
+	if exist $(BISON_PROGRAM) \
 	( \
-		$(bison_cygwin_bin) $(bison_args) \
+		$(BISON_PROGRAM) $(bison_args) \
 	) \
-	else \
-	( \
-		$(bison_bin) $(bison_args) \
-	)
 
 $(core_dir)\pbrtparse.hh : $(core_dir)\pbrtparse.hpp
 	if exist $(core_dir)\pbrtparse.hh del $(core_dir)\pbrtparse.hh
 	ren $(core_dir)\pbrtparse.hpp pbrtparse.hh
 
 $(core_dir)\pbrtlex.cpp $(core_dir)\pbrtparse.hh : $(core_dir)\pbrtlex.ll
-	if exist $(flex_cygwin_bin) \
+	if exist $(FLEX_PROGRAM) \
 	( \
-		$(flex_cygwin_bin) $(flex_args) \
+		$(FLEX_PROGRAM) $(flex_args) \
 	) \
-	else \
-	( \
-		$(flex_bin) $(flex_args) \
-	)


### PR DESCRIPTION
My motivation for this pull request came from when I cloned a clean git repo on my Windows 7 box using Visual Studio 2013. After fixing a few small issues that were documented online or through course websites (e.g. #include <algorithm> for std::min), I still was hitting a build error.

After digging a bit deeper, I discovered that the make file was assuming that I had cygwin installed and that bison and flex lived inside of cygwin's install directory. I decided that this was a fairly big assumption to make so I brushed up on batch and make to figure out a better alternative.

#### Things to note:
- The for loop iterates over Windows' available drives and searches for win_bison.exe and win_flex.exe if they have not been previously defined. I was concerned about renamed files (e.g. someone cutting the win_ from the file name), but this seemed like a good solution for most use cases.
- I tried to accomplish the same search functionality inside the makefile but nmake is missing a few needed capabilities. I assumed that nmake was used because it comes packaged with Visual Studio. I instead chose to search from the batch file and then pass to the makefile through command line arguments.
- Once finished, I cleaned/rebuilt my VS solution and it finished without errors.
- I only made changes in the vs2012 directory. I already had to update the .sln and related files to vs2013. If this PR is accepted, I would recommend making similar changes to the other visual studio offerings and adding a vs2013 dir. I did not do so for this PR to make the proposed change explicitly clear.

Please let me know if you have any questions on the questions or suggestions for how this can be improved. I hope this can be merged in soonish to save some other Windows users some time.