### PR TITLE
Fix vs2015 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ src/pbrt.vs*/*.opensdf
 src/pbrt.vs*/ipch
 src/pbrt.vs*/*.suo
 src/pbrt.vs*/*.user
+src/pbrt.vs*/*.VC.opendb
+src/pbrt.vs*/.vs
 
 # VS Build folders
 tmp/

--- a/src/pbrt.vs2015/libpbrt.vcxproj
+++ b/src/pbrt.vs2015/libpbrt.vcxproj
@@ -1286,19 +1286,15 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="UniversalCRT.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="UniversalCRT.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="UniversalCRT.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="UniversalCRT.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/src/pbrt.vs2015/pbrt.sln
+++ b/src/pbrt.vs2015/pbrt.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pbrt", "pbrt.vcxproj", "{7C350267-019A-43D2-BA77-0B3DF4C94EB8}"
 	ProjectSection(ProjectDependencies) = postProject
 		{2E030F4C-B2AE-476C-8E40-A326B3840F6C} = {2E030F4C-B2AE-476C-8E40-A326B3840F6C}


### PR DESCRIPTION
- fix .sln so opens in vs2015 when double-clicked
- remove missing UniversalCRT.props reference (which caused libpbrt not to load)
- ignore vc.opendb file and .vs folder